### PR TITLE
legacy: records latest only fix

### DIFF
--- a/invenio_migrator/legacy/records.py
+++ b/invenio_migrator/legacy/records.py
@@ -107,7 +107,7 @@ def dump(recid, from_date, with_json=True, latest_only=False, **kwargs):
 
     # Grab latest only
     if latest_only:
-        revision_iter = [get_record_revisions(recid, from_date)[0]]
+        revision_iter = [get_record_revisions(recid, from_date)[-1]]
     else:
         revision_iter = get_record_revisions(recid, from_date)
 


### PR DESCRIPTION
* Fixes bug where latest only would dump the first instead of the last
  revision.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>