### PR TITLE
records: revision loading fix

### DIFF
--- a/invenio_migrator/records.py
+++ b/invenio_migrator/records.py
@@ -101,7 +101,7 @@ class RecordDumpLoader(object):
             record.model.json = revision
             record.model.created = timestamp.replace(tzinfo=None)
             db.session.commit()
-        return record
+        return Record(record.model.json, model=record.model)
 
     @staticmethod
     def create_pids(record_uuid, pids):


### PR DESCRIPTION
* Fixes bug that would cause the initial revision to be the most recent
  when files where also added to the record.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>