### PR TITLE
legacy: involve users' passwords in migration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,4 @@ Utilities for migrating past Invenio versions to Invenio 3.0.
 
 - Esteban J. G. Gabancho <esteban.gabancho@gmail.com>
 - Lars Holm Nielsen <https://github.com/lnielsen>
+- Orestis Melkonian <melkon.or@gmail.com>

--- a/invenio_migrator/legacy/users.py
+++ b/invenio_migrator/legacy/users.py
@@ -39,8 +39,6 @@ def get(*args, **kwargs):
 def dump(u, from_date, with_json=True, latest_only=False, **kwargs):
     """Dump the users as a list of dictionaries.
 
-    TODO: This is only dumping user info without passwords.
-
     :param u: User to be dumped.
     :type u: `invenio_accounts.models.User [Invenio2.x]`
     :returns: User serialized to dictionary.
@@ -48,6 +46,8 @@ def dump(u, from_date, with_json=True, latest_only=False, **kwargs):
     """
     return dict(id=u.id,
                 email=u.email,
+                password=u.password,
+                password_salt=u.password_salt,
                 note=u.note,
                 given_names=u.given_names,
                 family_name=u.family_name,

--- a/invenio_migrator/tasks/users.py
+++ b/invenio_migrator/tasks/users.py
@@ -56,10 +56,17 @@ def load_user(data):
     if data['note'] == '1':
         confirmed_at = datetime.utcnow()
 
+    salt = data['password_salt']
+    checksum = data['password']
+    # Test if password hash is in Modular Crypt Format
+    if checksum.startswith('$'):
+        new_password = checksum
+    else:
+        new_password = str.join('$', ['', u'invenio-aes', salt, checksum])
     with db.session.begin_nested():
         obj = User(
             id=data['id'],
-            password=None,
+            password=new_password,
             email=email,
             confirmed_at=confirmed_at,
             last_login_at=last_login,

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ extras_require = {
     ],
     'userprofiles': [
         'invenio-userprofiles>=1.0.0a4',
+        'Flask-Security>=1.7.5',
     ],
     'tests': tests_require,
 }

--- a/tests/data/users.json
+++ b/tests/data/users.json
@@ -2,6 +2,8 @@
   {
     "id": "1",
     "email": "user1@invenio.org",
+    "password": "9e9ce44cd9df2b201f51947e03bccbe2",
+    "password_salt": "user1@invenio.org",
     "note": "1",
     "given_names": "",
     "family_name": "",
@@ -12,6 +14,8 @@
   {
     "id": "2",
     "email": "user2@invenio.org",
+    "password": "adklfhaty489g43956349562937525asdfsdf",
+    "password_salt": "user2@invenio.org",
     "note": "1",
     "given_names": "",
     "family_name": "",


### PR DESCRIPTION
* FIX Includes `password` and `password_salt` fields to users' JSON dumps.
  (closes #26)

* FIX Loads users' passwords on the datastore, using Modular Crypt Format.

* Enables automatic user migration.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>