### PR TITLE
legacy: user model import alternative

### DIFF
--- a/invenio_migrator/legacy/users.py
+++ b/invenio_migrator/legacy/users.py
@@ -31,7 +31,10 @@ from .utils import dt2iso_or_empty
 
 def get(*args, **kwargs):
     """Get users."""
-    from invenio.modules.accounts.models import User
+    try:
+        from invenio.modules.accounts.models import User
+    except ImportError:
+        from invenio_accounts.models import User
     q = User.query
     return q.count(), q.all()
 


### PR DESCRIPTION
* Allows installations with Invenio between versions 2 and 3 to use
  user dump functions.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>