### PR TITLE
global: remote account migration addition

### DIFF
--- a/invenio_migrator/cli.py
+++ b/invenio_migrator/cli.py
@@ -161,6 +161,19 @@ def loadusers(source):
 @dumps.command()
 @click.argument('source', type=click.File('r'), default=sys.stdin)
 @with_appcontext
+def loadremoteaccount(source):
+    """Load remote accounts."""
+    from .tasks.remoteaccount import load_remoteacount
+    click.echo('Loading dump...')
+    data = json.load(source)
+    with click.progressbar(data) as remoteaccounts:
+        for r in remoteaccounts:
+            load_remoteacount.delay(r)
+
+
+@dumps.command()
+@click.argument('source', type=click.File('r'), default=sys.stdin)
+@with_appcontext
 def loaddeposit(source):
     """Load deposit."""
     from .tasks.deposit import load_deposit

--- a/invenio_migrator/legacy/remoteaccount.py
+++ b/invenio_migrator/legacy/remoteaccount.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""RemoteAccount dump functions."""
+
+from __future__ import absolute_import, print_function
+
+
+def get(*args, **kwargs):
+    """Get remoteaccounts."""
+    try:
+        from invenio.modules.accounts.models import User
+    except ImportError:
+        from invenio_accounts.models import User
+    q = User.query
+    return q.count(), q.all()
+
+
+def dump(u, from_date, **kwargs):
+    """Dump the remoteaccounts as a list of dictionaries."""
+    from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+    try:
+        from invenio.modules.oauthclient.models import RemoteAccount
+    except ImportError:
+        from invenio_oauthclient.models import RemoteAccount
+    try:
+        from invenio.modules.accounts.models import UserEXT
+    except ImportError:
+        from invenio_accounts.models import UserEXT
+
+    # First fetch all the remote account information
+    remoteaccount = {}
+    try:
+        result = RemoteAccount.query.filter_by(user_id=u.id).one()
+        remoteaccount = dict(id=result.id,
+                             user_id=result.user_id,
+                             client_id=result.client_id,
+                             extra_data=result.extra_data)
+    except NoResultFound:
+        print(
+            'INFO: user id {} has no remote account'.format(u.id))
+    except MultipleResultsFound:
+        print(
+            'WARN: user id {} has multiple remote account'.format(u.id))
+
+    # And then fetch the user ext information
+    userext = {}
+    try:
+        result = UserEXT.query.filter_by(id_user=u.id).one()
+        userext = dict(id=result.id,
+                       id_user=result.id_user,
+                       method=result.method)
+    except NoResultFound:
+        print('INFO: user id {} has no userext entry'.format(u.id))
+    except MultipleResultsFound:
+        print(
+            'WARN: user id {} has multiple userext entries'.format(u.id))
+
+    return {
+        'remoteaccount': remoteaccount,
+        'userext': userext
+    }

--- a/invenio_migrator/tasks/remoteaccount.py
+++ b/invenio_migrator/tasks/remoteaccount.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Celery task for remote account migration."""
+
+from __future__ import absolute_import, print_function
+
+from celery import shared_task
+
+from invenio_db import db
+from invenio_oauthclient.models import RemoteAccount
+from invenio_oauthclient.models import UserIdentity
+
+
+@shared_task()
+def load_remoteacount(data):
+    """Load remoteaccount from data dump.
+
+    :param data: Dictionary containing user data.
+    :type data: dict
+    """
+    with db.session.begin_nested():
+        remoteaccount = data['remoteaccount']
+        if remoteaccount:
+            obj = RemoteAccount(
+                id=remoteaccount['id'],
+                user_id=remoteaccount['user_id'],
+                client_id=remoteaccount['client_id'],
+                extra_data=remoteaccount['extra_data']
+            )
+            db.session.add(obj)
+
+        userext = data['userext']
+        if userext:
+            obj = UserIdentity(
+                id=userext['id'],
+                method=userext['method'],
+                id_user=userext['id_user']
+            )
+            db.session.add(obj)
+
+    db.session.commit()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ extras_require = {
         'dojson>=1.0.0',
         'invenio-db[versioning]>=1.0.0a9',
         'invenio-files-rest>=1.0.0a1',
+        'invenio-oauthclient>=1.0.0a6',
         'invenio-pidstore>=1.0.0a6',
         'invenio-records>=1.0.0a9',
         'invenio-records-files>=1.0.0a1',
@@ -120,6 +121,7 @@ setup(
             'communities = invenio_migrator.tasks.communities',
             'deposit = invenio_migrator.tasks.deposit',
             'records = invenio_migrator.tasks.records',
+            'remoteaccount = invenio_migrator.tasks.remoteaccount',
             'users = invenio_migrator.tasks.users',
         ],
         'invenio_migrator.things': [
@@ -127,6 +129,7 @@ setup(
             'files = invenio_migrator.legacy.bibdocfile',
             'communities = invenio_migrator.legacy.communities',
             'featured = invenio_migrator.legacy.featured_communities',
+            'remoteaccount = invenio_migrator.legacy.remoteaccount',
             'users = invenio_migrator.legacy.users',
             'deposit = invenio_migrator.legacy.deposit',
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ from invenio_deposit import InvenioDeposit
 from invenio_files_rest import InvenioFilesREST
 from invenio_files_rest.models import Bucket, Location, ObjectVersion
 from invenio_jsonschemas.ext import InvenioJSONSchemas
+from invenio_oauthclient.ext import InvenioOAuthClient
 from invenio_pidstore import InvenioPIDStore
 from invenio_pidstore.fetchers import FetchedPID
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus, \
@@ -93,6 +94,7 @@ def app(request):
     Babel(app_)
     InvenioFilesREST(app_)
     InvenioMigrator(app_)
+    InvenioOAuthClient(app_)
 
     with app_.app_context():
         yield app_
@@ -151,6 +153,30 @@ def records_json(datadir):
     with open(join(datadir, 'records.json')) as fp:
         records = json.load(fp)
     return records
+
+
+@pytest.fixture()
+def remoteaccount_json(datadir):
+    """Load remoteaccount json."""
+    with open(join(datadir, 'remoteaccount.json')) as fp:
+        remoteaccounts = json.load(fp)
+    return remoteaccounts
+
+
+@pytest.fixture()
+def remoteaccount_users(db):
+    """Test user for deposit loading."""
+    u1 = User(id=1, email='user@invenio.org',
+              password='change_me', active=True)
+
+    db.session.add(u1)
+    db.session.commit()
+    u2 = User(id=2, email='user2@invenio.org',
+              password='change_me', active=True)
+
+    db.session.add(u2)
+    db.session.commit()
+    return u1, u2
 
 
 @pytest.fixture()

--- a/tests/data/remoteaccount.json
+++ b/tests/data/remoteaccount.json
@@ -1,0 +1,28 @@
+[
+  {
+    "userext": {},
+    "remoteaccount": {
+      "extra_data": {
+        "orcid": "0000-0001-9999-9999"
+      },
+      "user_id": 1,
+      "id": 4,
+      "client_id": "0000-0000-0000-0000"
+    }
+  },
+  {
+    "userext": {
+      "id_user": 2,
+      "method": "orcid",
+      "id": "0000-0002-XXXX-YYYY"
+    },
+    "remoteaccount": {
+      "extra_data": {
+        "orcid": "0000-0002-XXXX-YYYY"
+      },
+      "user_id": 2,
+      "id": 67,
+      "client_id": "0000-0000-0000-0000"
+    }
+  }
+]

--- a/tests/test_remoteaccount_load.py
+++ b/tests/test_remoteaccount_load.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test remote account loading."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_oauthclient.models import RemoteAccount, UserIdentity
+
+from invenio_migrator.tasks.remoteaccount import load_remoteacount
+
+
+def test_deposit_load_task(db, remoteaccount_users, remoteaccount_json):
+    """Test the remoteaccount loading task."""
+    for remoteaccount in remoteaccount_json:
+        load_remoteacount.delay(remoteaccount)
+
+    assert RemoteAccount.query.count() == 2
+
+    remoteaccount1, remoteaccount2 = RemoteAccount.query.all()
+    assert remoteaccount1.user_id == 1
+    assert remoteaccount1.client_id == u'0000-0000-0000-0000'
+    assert remoteaccount1.extra_data == {u'orcid': u'0000-0001-9999-9999'}
+    assert remoteaccount2.user_id == 2
+    assert remoteaccount2.client_id == u'0000-0000-0000-0000'
+    assert remoteaccount2.extra_data == {u'orcid': u'0000-0002-XXXX-YYYY'}
+
+    assert UserIdentity.query.count() == 1
+
+    useridentity = UserIdentity.query.one()
+    assert useridentity.id == u'0000-0002-XXXX-YYYY'
+    assert useridentity.method == u'orcid'
+    assert useridentity.id_user == 2


### PR DESCRIPTION
* Adds migration for RemoteAccount and UserEXT tables.

* NOTE: does not include migration of RemoteToken.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>