### PR TITLE
You are forced to install all the extras

### DIFF
--- a/invenio_migrator/tasks/deposit.py
+++ b/invenio_migrator/tasks/deposit.py
@@ -31,7 +31,6 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 from os.path import splitext
 
-from invenio_pidstore.models import RecordIdentifier
 
 from .utils import empty_str_if_none
 from .errors import DepositMultipleRecids
@@ -65,7 +64,8 @@ def create_record_and_pid(data):
              `invenio_pidstore.models.PersistentIdentifier`)
     """
     from invenio_records.api import Record
-    from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+    from invenio_pidstore.models import PersistentIdentifier, PIDStatus, \
+        RecordIdentifier
 
     deposit = Record.create(data=data)
 
@@ -88,7 +88,8 @@ def create_record_and_pid(data):
 def create_files_and_sip(deposit, dep_pid):
     """Create deposit Bucket, Files and SIPs."""
     from invenio_pidstore.errors import PIDDoesNotExistError
-    from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+    from invenio_pidstore.models import PersistentIdentifier, PIDStatus, \
+        RecordIdentifier
     from invenio_sipstore.errors import SIPUserDoesNotExist
     from invenio_sipstore.models import SIP, RecordSIP, SIPFile
     from invenio_files_rest.models import Bucket, FileInstance, ObjectVersion

--- a/invenio_migrator/tasks/oauth2server.py
+++ b/invenio_migrator/tasks/oauth2server.py
@@ -27,7 +27,6 @@
 from __future__ import absolute_import, print_function
 
 from celery import shared_task
-from invenio_oauth2server.models import Client, Token
 
 from .utils import iso2dt_or_none, load_common
 
@@ -35,11 +34,13 @@ from .utils import iso2dt_or_none, load_common
 @shared_task()
 def load_client(data):
     """Load the oauth2server client from data dump."""
+    from invenio_oauth2server.models import Client
     load_common(Client, data)
 
 
 @shared_task()
 def load_token(data):
     """Load the oauth2server token from data dump."""
+    from invenio_oauth2server.models import Token
     data['expires'] = iso2dt_or_none(data['expires'])
     load_common(Token, data)

--- a/invenio_migrator/tasks/oauthclient.py
+++ b/invenio_migrator/tasks/oauthclient.py
@@ -27,7 +27,6 @@
 from __future__ import absolute_import, print_function
 
 from celery import shared_task
-from invenio_oauthclient.models import RemoteAccount, RemoteToken, UserIdentity
 
 from .utils import load_common
 
@@ -39,6 +38,7 @@ def load_remoteaccount(data):
     :param data: Dictionary containing remote accounts data.
     :type data: dict
     """
+    from invenio_oauthclient.models import RemoteAccount
     load_common(RemoteAccount, data)
 
 
@@ -49,6 +49,7 @@ def load_remotetoken(data):
     :param data: Dictionary containing remote tokens data.
     :type data: dict
     """
+    from invenio_oauthclient.models import RemoteToken
     load_common(RemoteToken, data)
 
 
@@ -59,4 +60,5 @@ def load_userext(data):
     :param data: Dictionary containing user identities.
     :type data: dict
     """
+    from invenio_oauthclient.models import UserIdentity
     load_common(UserIdentity, data)


### PR DESCRIPTION
That's because the tasks that use them import them in the global scope, making celery fail to start if the deps are not installed.

It should defer the importing and do it only inside the tasks so it only fails when you try to use those 'extra' tasks.