### PR TITLE
packaging: pin Flask-Login to avoid collision

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ extras_require = {
         'invenio-sipstore>=1.0.0a1',
     ],
     'deposit': [
+        # Temporary pin to avoid collision with Flask-Security
+        'Flask-Login>=0.3.2,<0.4',
         'invenio-deposit>=1.0.0.dev20160404',
     ],
     'communities': [


### PR DESCRIPTION
* It turns out that invenio-deposit requirements are parsed before
  (and ignoring) the Flask-Secure ones, and that leads to a version
  collision for that package. (closes #58)

Signed-off-by: David Caro <david@dcaro.es>