### PR TITLE
records: dump creation_date in bibrec

### DIFF
--- a/invenio_migrator/legacy/records.py
+++ b/invenio_migrator/legacy/records.py
@@ -154,6 +154,23 @@ def get(query, from_date, **kwargs):
     return len(recids), recids
 
 
+def get_creation_date_in_bibrec(recid, fmt="%Y-%m-%d %H:%i:%s"):
+    """Get correct creation date for a record."""
+    try:
+        from invenio.dbquery import run_sql
+    except ImportError:
+        from invenio.legacy.dbquery import run_sql
+
+    res = run_sql(
+        "SELECT DATE_FORMAT(creation_date,%s) FROM bibrec WHERE id=%s", (fmt, recid), 1
+    )
+    if res:
+        return res[0][0]
+    raise ValueError(
+        "No creation date found in bibrec for recid {0}".format(recid)
+    )
+
+
 def dump(recid,
          from_date,
          with_json=False,
@@ -195,5 +212,7 @@ def dump(recid,
                 json=dump_record_json(marcxml) if with_json else None, ))
 
     record_dump['files'] = dump_bibdoc(recid, from_date)
+
+    record_dump['creation_date'] = get_creation_date_in_bibrec(recid)
 
     return record_dump


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/397

:heart: Thank you for your contribution!

### Description


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
